### PR TITLE
Dynamically calculate the size of HugePage

### DIFF
--- a/src/cma/cma_utils.cpp
+++ b/src/cma/cma_utils.cpp
@@ -5,26 +5,25 @@
 
 int CmaGetReservedHugePagesCount(void)
 {
+
 #ifdef WITH_LOCK_PAGES
+
 	MEMORYSTATUSEX mem_status;
 	mem_status.dwLength = sizeof(mem_status);
 
 	GlobalMemoryStatusEx(&mem_status);
 
-	if (mem_status.ullAvailPhys > 17179869184) // Avail > 16G
-		return 8;
-
-	if (mem_status.ullAvailPhys > 12884901888) // Avail > 12G
-		return 6;
+	const uint64_t GSIZE = 1024 * 1024 * 1024; // "ull" in "ullAvailPhys" indicates it is unsigned long long type, so use "uint64_t" here
 
 	if (mem_status.ullAvailPhys > 8589934592) // Avail > 8G
-		return 4;
+		return mem_status.ullAvailPhys / GSIZE / 2; // Reserved size is set to half of the avail phys_mem
 
 	if (mem_status.ullAvailPhys > 6442450944) // Avail > 6G
 		return 2;
 
 	if (mem_status.ullAvailPhys > 4294967296) // Avail > 4G
 		return 1;
+
 #endif // WITH_LOCK_PAGES
 
 	return 0;


### PR DESCRIPTION
动态计算 `HugePage` 所需内存
- 1G - 6G: 维持原状
- \> 8G: 自动设置为可用内存的一半